### PR TITLE
refactor: use whiskers

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers ksyntaxhighlighting.tera

--- a/justfile
+++ b/justfile
@@ -1,5 +1,0 @@
-_default:
-  @just --list
-
-build:
-  whiskers ksyntaxhighlighting.tera

--- a/ksyntaxhighlighting.tera
+++ b/ksyntaxhighlighting.tera
@@ -1,0 +1,1180 @@
+---
+whiskers:
+  version: "2.3.0"
+  matrix:
+    - flavor
+  filename: "themes/{{ flavor.identifier }}.theme"
+---
+{
+    "custom-styles": {
+        "Alerts": {
+            "Alert Level 1": {
+                "background-color": "#{{ red.hex }}",
+                "selected-text-color": "#{{ crust.hex }}",
+                "text-color": "#{{ crust.hex }}"
+            },
+            "Alert Level 2": {
+                "background-color": "#{{ yellow.hex }}",
+                "selected-text-color": "#{{ crust.hex }}",
+                "text-color": "#{{ crust.hex }}"
+            },
+            "Alert Level 3": {
+                "background-color": "#{{ green.hex }}",
+                "selected-text-color": "#{{ crust.hex }}",
+                "text-color": "#{{ crust.hex }}"
+            }
+        },
+        "Bash": {
+            "Backquote": {
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            },
+            "Builtin": {
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            },
+            "Command": {
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            },
+            "Control": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Dollar Prefix": {
+                "italic": true,
+                "selected-text-color": "#{{ maroon.hex }}",
+                "text-color": "#{{ maroon.hex }}"
+            },
+            "Escape": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Expression": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "Glob": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Option": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Parameter Expansion": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "String Escape": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Variable": {
+                "italic": true,
+                "selected-text-color": "#{{ maroon.hex }}",
+                "text-color": "#{{ maroon.hex }}"
+            }
+        },
+        "BibTeX": {
+            "Command": {
+                "selected-text-color": "#{{ flamingo.hex }}",
+                "text-color": "#{{ flamingo.hex }}"
+            },
+            "Entry": {
+                "selected-text-color": "#{{ flamingo.hex }}",
+                "text-color": "#{{ flamingo.hex }}"
+            },
+            "Field": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Ref Key": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            }
+        },
+        "C": {
+            "Attribute": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Prep. Lib": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Preprocessor": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Standard Attribute": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Standard Suffix": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            }
+        },
+        "C++": {
+            "Qt Classes": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Qt Functions": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Qt Types": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            }
+        },
+        "CMake": {
+            "Aliased Targets": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Builtin Variable": {
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}"
+            },
+            "Command": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Environment Variable Substitution": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "False Special Arg": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Generator Expression": {
+                "selected-text-color": "#{{ yellow.hex }}",
+                "text-color": "#{{ yellow.hex }}"
+            },
+            "Generator Expression Keyword": {
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            },
+            "Internal Name": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Named Args": {
+                "bold": true,
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Property": {
+                "bold": true,
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Region Marker": {
+                "selected-text-color": "#{{ overlay1.hex }}",
+                "text-color": "#{{ overlay1.hex }}"
+            },
+            "Special Args": {
+                "bold": true,
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "True Special Arg": {
+                "bold": true,
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "User Function/Macro": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Variable Substitution": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Version Arg": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            }
+        },
+        "CSS": {
+            "At Rule": {
+                "italic": true,
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "Color": {
+                "selected-text-color": "#{{ yellow.hex }}",
+                "text-color": "#{{ yellow.hex }}"
+            },
+            "Function": {
+                "selected-text-color": "#{{ teal.hex }}",
+                "text-color": "#{{ teal.hex }}"
+            },
+            "Operator": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Property": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Selector Attribute": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Selector Class": {
+                "selected-text-color": "#{{ teal.hex }}",
+                "text-color": "#{{ teal.hex }}"
+            },
+            "Selector Id": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Selector Pseudo": {
+                "selected-text-color": "#{{ teal.hex }}",
+                "text-color": "#{{ teal.hex }}"
+            },
+            "Selector Tag": {
+                "selected-text-color": "#{{ yellow.hex }}",
+                "text-color": "#{{ yellow.hex }}"
+            },
+            "Separator Symbol": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            },
+            "Unit": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Value": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            }
+        },
+        "Diff": {
+            "Added line": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Changed line (new)": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Changed line (old)": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Removed line": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            }
+        },
+        "Doxygen": {
+            "Custom Tags": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "Dot Graph": {
+                "text-color": "#{{ green.hex }}"
+            },
+            "Entities": {
+                "text-color": "#{{ peach.hex }}"
+            },
+            "Formulas": {
+                "text-color": "#{{ green.hex }}"
+            },
+            "Message Sequence Chart": {
+                "text-color": "#{{ green.hex }}"
+            },
+            "Tags": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            }
+        },
+        "Fish": {
+            "Builtin": {
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            },
+            "Escape": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            },
+            "Option": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "Redirection": {
+                "selected-text-color": "#{{ sky.hex }}",
+                "text-color": "#{{ sky.hex }}"
+            },
+            "Separator": {
+                "selected-text-color": "#{{ teal.hex }}",
+                "text-color": "#{{ teal.hex }}"
+            },
+            "Variable": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            }
+        },
+        "GCCExtensions": {
+            "GNU Extensions": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "GNU Functions": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "GNU Macros": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            }
+        },
+        "Go": {
+            "Builtin Function": {
+                "selected-text-color": "#{{ flamingo.hex }}",
+                "text-color": "#{{ flamingo.hex }}"
+            },
+            "Data Type": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Keyword": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            },
+            "Predeclared Identifier": {
+                "bold": true
+            }
+        },
+        "Godot": {
+            "Definition Keyword": {
+                "italic": true,
+                "selected-text-color": "#{{ yellow.hex }}",
+                "text-color": "#{{ yellow.hex }}"
+            },
+            "Function Call": {
+                "italic": true
+            },
+            "Special Variable": {
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            },
+            "UnusedVariable": {
+                "italic": false,
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            }
+        },
+        "HTML": {
+            "Attribute": {
+                "selected-text-color": "#{{ yellow.hex }}",
+                "text-color": "#{{ yellow.hex }}"
+            },
+            "Element": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Element Symbols": {
+                "selected-text-color": "#{{ teal.hex }}",
+                "text-color": "#{{ teal.hex }}"
+            },
+            "Other Text": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            }
+        },
+        "ISO C++": {
+            "Boost Stuff": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Keyword": {
+                "italic": true,
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            },
+            "Prep. Lib": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Preprocessor": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Raw String": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Standard Classes": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Standard Macros": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Standard Suffix": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Type Modifiers": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            }
+        },
+        "JSON": {
+            "Style_Seperator_Array": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Style_Seperator_Pair": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Style_String_Key": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            }
+        },
+        "Java": {
+            "Function": {
+                "italic": true,
+                "selected-text-color": "#{{ surface2.hex }}",
+                "text-color": "#{{ surface2.hex }}"
+            },
+            "Java15": {
+                "italic": true,
+                "selected-text-color": "#{{ yellow.hex }}",
+                "text-color": "#{{ yellow.hex }}"
+            }
+        },
+        "JavaScript": {
+            "Built-in Objects": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Constant": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Function Declaration": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Function Name": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "JSON": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Object Member": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Object Method (Built-in)": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Pattern Character Class": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Pattern Internal Operator": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Regular Expression": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Reserved": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Template": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            }
+        },
+        "Javadoc": {
+            "BlockTag": {
+                "italic": true,
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            }
+        },
+        "Kconfig": {
+            "Help Text": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Property": {
+                "selected-text-color": "#{{ flamingo.hex }}",
+                "text-color": "#{{ flamingo.hex }}"
+            },
+            "Source": {
+                "text-color": "#f50000"
+            }
+        },
+        "Kotlin": {
+            "Function": {
+                "italic": true
+            },
+            "Keyword": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "String Interpolation": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            }
+        },
+        "LaTeX": {
+            "Ampersand": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            },
+            "Builtin Macro": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Column Separator": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Environment": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            },
+            "Macro": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Math": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            },
+            "Option Text": {
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            },
+            "Reference": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            },
+            "Region Marker": {
+                "italic": true,
+                "selected-text-color": "#{{ overlay1.hex }}",
+                "text-color": "#{{ overlay1.hex }}"
+            },
+            "Sectioning Macro": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Sectioning Math": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Structure": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Verbatim": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            },
+            "Verbatim Code": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            }
+        },
+        "Lua": {
+            "Constant": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Keyword": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Special Variable": {
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            }
+        },
+        "Makefile": {
+            "Silent": {
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            }
+        },
+        "Markdown": {
+            "Auto-Link": {
+                "italic": true,
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}",
+                "underline": true
+            },
+            "Blockquote": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Blockquote: Emphasis Text": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "Blockquote: Link": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Blockquote: Normal Text": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Blockquote: Strikethrough Text": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Blockquote: Strong Text": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "Blockquote: Strong-Emphasis Text": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "Code": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Email": {
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}"
+            },
+            "Emphasis Text": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "Fenced Code": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Inline Image": {
+                "selected-text-color": "#{{ lavender.hex }}",
+                "text-color": "#{{ lavender.hex }}"
+            },
+            "Inline Image: Link": {
+                "italic": true,
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}"
+            },
+            "Line Break": {
+                "text-color": "#{{ text.hex }}"
+            },
+            "Link": {
+                "italic": true,
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}"
+            },
+            "List": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "List: Checkbox": {
+                "selected-text-color": "#{{ teal.hex }}",
+                "text-color": "#{{ teal.hex }}"
+            },
+            "List: Emphasis Text": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "List: Link": {
+                "italic": true,
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}"
+            },
+            "List: Normal Text": {
+                "selected-text-color": "#{{ teal.hex }}",
+                "text-color": "#{{ teal.hex }}"
+            },
+            "List: Strong Text": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "List: Strong-Emphasis Text": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "Mailto-Link": {
+                "italic": true,
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}",
+                "underline": true
+            },
+            "Metadata": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Metadata Title": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Normal Text: Link": {
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}"
+            },
+            "Number List": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            },
+            "Reference Image": {
+                "bold": true,
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}",
+                "underline": true
+            },
+            "Reference-Link": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Reference-Link ID": {
+                "italic": true,
+                "selected-text-color": "#{{ lavender.hex }}",
+                "text-color": "#{{ lavender.hex }}"
+            },
+            "Reference-Link Name": {
+                "italic": true,
+                "selected-text-color": "#{{ lavender.hex }}",
+                "text-color": "#{{ lavender.hex }}"
+            },
+            "Reference-Link Target": {
+                "selected-text-color": "#{{ lavender.hex }}",
+                "text-color": "#{{ lavender.hex }}"
+            },
+            "Reference-Link Target: Link": {
+                "italic": true,
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}"
+            },
+            "Reference-Link: Email": {
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}"
+            },
+            "Reference-Link: Link": {
+                "italic": true,
+                "selected-text-color": "#{{ rosewater.hex }}",
+                "text-color": "#{{ rosewater.hex }}"
+            },
+            "Strong Text": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            },
+            "Strong-Emphasis Text": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            }
+        },
+        "Python": {
+            "Builtin Function": {
+                "italic": true,
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            },
+            "F-String": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Import": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            },
+            "Raw B-String": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Raw F-String": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Raw String": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            }
+        },
+        "Ruby": {
+            "Constant": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Default globals": {
+                "selected-text-color": "#{{ flamingo.hex }}",
+                "text-color": "#{{ flamingo.hex }}"
+            },
+            "Global Constant": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Global Variable": {
+                "selected-text-color": "#{{ flamingo.hex }}",
+                "text-color": "#{{ flamingo.hex }}"
+            },
+            "Here Document": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Instance Variable": {
+                "selected-text-color": "#{{ flamingo.hex }}",
+                "text-color": "#{{ flamingo.hex }}"
+            },
+            "Kernel methods": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            },
+            "Message": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Raw String": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Regular Expression": {
+                "selected-text-color": "#{{ pink.hex }}",
+                "text-color": "#{{ pink.hex }}"
+            }
+        },
+        "Rust": {
+            "Attribute": {
+                "italic": true
+            },
+            "CharEscape": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Definition": {
+                "italic": true,
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Macro": {
+                "selected-text-color": "#{{ sky.hex }}",
+                "text-color": "#{{ sky.hex }}"
+            },
+            "Scope": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Self": {
+                "selected-text-color": "#{{ peach.hex }}",
+                "text-color": "#{{ peach.hex }}"
+            },
+            "Trait": {
+                "italic": true,
+                "selected-text-color": "#{{ yellow.hex }}",
+                "text-color": "#{{ yellow.hex }}"
+            }
+        },
+        "SQL": {
+            "Operator Keyword": {
+                "selected-text-color": "#{{ mauve.hex }}",
+                "text-color": "#{{ mauve.hex }}"
+            }
+        },
+        "TOML": {
+            "Key": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "LitString": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            }
+        },
+        "XML": {
+            "Attribute": {
+                "selected-text-color": "#{{ yellow.hex }}",
+                "text-color": "#{{ yellow.hex }}"
+            },
+            "Doctype": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Doctype Name": {
+                "selected-text-color": "#{{ yellow.hex }}",
+                "text-color": "#{{ yellow.hex }}"
+            },
+            "Doctype Symbols": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "Element": {
+                "selected-text-color": "#{{ blue.hex }}",
+                "text-color": "#{{ blue.hex }}"
+            },
+            "PI Symbols": {
+                "selected-text-color": "#{{ yellow.hex }}",
+                "text-color": "#{{ yellow.hex }}"
+            },
+            "Processing Instruction": {
+                "selected-text-color": "#{{ yellow.hex }}",
+                "text-color": "#{{ yellow.hex }}"
+            }
+        },
+        "YAML": {
+            "Alert": {
+                "background-color": "#{{ red.hex }}",
+                "selected-text-color": "#{{ crust.hex }}",
+                "text-color": "#{{ crust.hex }}"
+            },
+            "Alias": {
+                "selected-text-color": "#{{ surface2.hex }}",
+                "text-color": "#{{ surface2.hex }}"
+            },
+            "Attribute": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Boolean": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Data Types": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Document Header": {
+                "selected-text-color": "#{{ teal.hex }}",
+                "text-color": "#{{ teal.hex }}"
+            },
+            "Escaped Character": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Float": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Integer": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Key Points Operator": {
+                "selected-text-color": "#{{ teal.hex }}",
+                "text-color": "#{{ teal.hex }}"
+            },
+            "List": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Literal/Folded Block": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Literal/Folded Operator": {
+                "selected-text-color": "#{{ green.hex }}",
+                "text-color": "#{{ green.hex }}"
+            },
+            "Normal Text": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Null": {
+                "selected-text-color": "#{{ text.hex }}",
+                "text-color": "#{{ text.hex }}"
+            },
+            "Operator": {
+                "selected-text-color": "#{{ teal.hex }}",
+                "text-color": "#{{ teal.hex }}"
+            }
+        },
+        "sed": {
+            "Last Line": {
+                "text-color": "#{{ peach.hex }}"
+            },
+            "Negation": {
+                "text-color": "#{{ peach.hex }}"
+            },
+            "Separator": {
+                "selected-text-color": "#{{ red.hex }}",
+                "text-color": "#{{ red.hex }}"
+            }
+        }
+    },
+    "editor-colors": {
+        "BackgroundColor": "#{{ base.hex }}",
+        "BracketMatching": "#{{ teal.hex }}",
+        "CodeFolding": "#{{ sapphire.hex }}",
+        "CurrentLine": "#{{ surface0.hex }}",
+        "CurrentLineNumber": "#{{ text.hex }}",
+        "IconBorder": "#{{ base.hex }}",
+        "IndentationLine": "#{{ surface0.hex }}",
+        "LineNumbers": "#{{ subtext0.hex }}",
+        "MarkBookmark": "#{{ mauve.hex }}",
+        "MarkBreakpointActive": "#{{ pink.hex }}",
+        "MarkBreakpointDisabled": "#{{ overlay0.hex }}",
+        "MarkBreakpointReached": "#{{ green.hex }}",
+        "MarkError": "#{{ red.hex }}",
+        "MarkExecution": "#{{ overlay2.hex }}",
+        "MarkWarning": "#{{ peach.hex }}",
+        "ModifiedLines": "#{{ peach.hex }}",
+        "ReplaceHighlight": "#{{ blue | mod(opacity=0.5) | get(key="hex") }}",
+        "SavedLines": "#{{ green.hex }}",
+        "SearchHighlight": "#{{ blue | mod(opacity=0.9) | get(key="hex") }}",
+        "Separator": "#{{ crust.hex }}",
+        "SpellChecking": "#{{ maroon.hex }}",
+        "TabMarker": "#{{ surface0.hex }}",
+        "TemplateBackground": "#{{ surface2.hex }}",
+        "TemplateFocusedPlaceholder": "#{{ teal.hex }}",
+        "TemplatePlaceholder": "#{{ sapphire.hex }}",
+        "TemplateReadOnlyPlaceholder": "#{{ maroon.hex }}",
+        "TextSelection": "#{{ red | mod(opacity=0.5) | get(key="hex") }}",
+        "WordWrapMarker": "#{{ surface2.hex }}"
+    },
+    "metadata": {
+        "copyright": [
+            "SPDX-FileCopyrightText: 2021 Catppuccin Org"
+        ],
+        "license": "SPDX-License-Identifier: MIT",
+        "name": "Catppuccin {{ flavor.name }}",
+        "revision": 3
+    },
+    "text-styles": {
+        "Alert": {
+            "bold": true,
+            "selected-text-color": "#{{ red.hex }}",
+            "text-color": "#{{ red.hex }}"
+        },
+        "Annotation": {
+            "selected-text-color": "#{{ yellow.hex }}",
+            "text-color": "#{{ yellow.hex }}"
+        },
+        "Attribute": {
+            "selected-text-color": "#{{ lavender.hex }}",
+            "text-color": "#{{ lavender.hex }}"
+        },
+        "BaseN": {
+            "selected-text-color": "#{{ peach.hex }}",
+            "text-color": "#{{ peach.hex }}"
+        },
+        "BuiltIn": {
+            "selected-text-color": "#{{ red.hex }}",
+            "text-color": "#{{ red.hex }}"
+        },
+        "Char": {
+            "selected-text-color": "#{{ pink.hex }}",
+            "text-color": "#{{ pink.hex }}"
+        },
+        "Comment": {
+            "italic": true,
+            "selected-text-color": "#{{ overlay0.hex }}",
+            "text-color": "#{{ overlay0.hex }}"
+        },
+        "CommentVar": {
+            "italic": true,
+            "selected-text-color": "#{{ overlay0.hex }}",
+            "text-color": "#{{ overlay0.hex }}"
+        },
+        "Constant": {
+            "selected-text-color": "#{{ peach.hex }}",
+            "text-color": "#{{ peach.hex }}"
+        },
+        "ControlFlow": {
+            "selected-text-color": "#{{ mauve.hex }}",
+            "text-color": "#{{ mauve.hex }}"
+        },
+        "DataType": {
+            "selected-text-color": "#{{ mauve.hex }}",
+            "text-color": "#{{ mauve.hex }}"
+        },
+        "DecVal": {
+            "selected-text-color": "#{{ peach.hex }}",
+            "text-color": "#{{ peach.hex }}"
+        },
+        "Documentation": {
+            "selected-text-color": "#{{ red.hex }}",
+            "text-color": "#{{ red.hex }}"
+        },
+        "Error": {
+            "selected-text-color": "#{{ red.hex }}",
+            "text-color": "#{{ red.hex }}",
+            "underline": true
+        },
+        "Extension": {
+            "selected-text-color": "#{{ blue.hex }}",
+            "text-color": "#{{ blue.hex }}"
+        },
+        "Float": {
+            "selected-text-color": "#{{ peach.hex }}",
+            "text-color": "#{{ peach.hex }}"
+        },
+        "Function": {
+            "selected-text-color": "#{{ blue.hex }}",
+            "text-color": "#{{ blue.hex }}"
+        },
+        "Import": {
+            "selected-text-color": "#{{ green.hex }}",
+            "text-color": "#{{ green.hex }}"
+        },
+        "Information": {
+            "selected-text-color": "#{{ peach.hex }}",
+            "text-color": "#{{ peach.hex }}"
+        },
+        "Keyword": {
+            "selected-text-color": "#{{ mauve.hex }}",
+            "text-color": "#{{ mauve.hex }}"
+        },
+        "Normal": {
+            "selected-text-color": "#{{ text.hex }}",
+            "text-color": "#{{ text.hex }}"
+        },
+        "Operator": {
+            "selected-text-color": "#{{ sky.hex }}",
+            "text-color": "#{{ sky.hex }}"
+        },
+        "Others": {
+            "selected-text-color": "#{{ peach.hex }}",
+            "text-color": "#{{ peach.hex }}"
+        },
+        "Preprocessor": {
+            "selected-text-color": "#{{ pink.hex }}",
+            "text-color": "#{{ pink.hex }}"
+        },
+        "RegionMarker": {
+            "italic": true,
+            "selected-text-color": "#{{ overlay0.hex }}",
+            "text-color": "#{{ overlay0.hex }}"
+        },
+        "SpecialChar": {
+            "selected-text-color": "#{{ pink.hex }}",
+            "text-color": "#{{ pink.hex }}"
+        },
+        "SpecialString": {
+            "selected-text-color": "#{{ red.hex }}",
+            "text-color": "#{{ red.hex }}"
+        },
+        "String": {
+            "selected-text-color": "#{{ green.hex }}",
+            "text-color": "#{{ green.hex }}"
+        },
+        "Variable": {
+            "selected-text-color": "#{{ pink.hex }}",
+            "text-color": "#{{ pink.hex }}"
+        },
+        "VerbatimString": {
+            "selected-text-color": "#{{ red.hex }}",
+            "text-color": "#{{ red.hex }}"
+        },
+        "Warning": {
+            "selected-text-color": "#{{ peach.hex }}",
+            "text-color": "#{{ peach.hex }}"
+        }
+    }
+}

--- a/ksyntaxhighlighting.tera
+++ b/ksyntaxhighlighting.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-  version: "2.3.0"
+  version: "^2.3.0"
   matrix:
     - flavor
   filename: "themes/{{ flavor.identifier }}.theme"

--- a/themes/frappe.theme
+++ b/themes/frappe.theme
@@ -661,8 +661,8 @@
                 "text-color": "#ca9ee6"
             },
             "Inline Image": {
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#babbf1",
+                "text-color": "#babbf1"
             },
             "Inline Image: Link": {
                 "italic": true,
@@ -740,17 +740,17 @@
             },
             "Reference-Link ID": {
                 "italic": true,
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#babbf1",
+                "text-color": "#babbf1"
             },
             "Reference-Link Name": {
                 "italic": true,
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#babbf1",
+                "text-color": "#babbf1"
             },
             "Reference-Link Target": {
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#babbf1",
+                "text-color": "#babbf1"
             },
             "Reference-Link Target: Link": {
                 "italic": true,
@@ -1003,8 +1003,8 @@
     },
     "editor-colors": {
         "BackgroundColor": "#303446",
-        "BracketMatching": "#32eebebe",
-        "CodeFolding": "#1a99d1db",
+        "BracketMatching": "#81c8be",
+        "CodeFolding": "#85c1dc",
         "CurrentLine": "#414559",
         "CurrentLineNumber": "#c6d0f5",
         "IconBorder": "#303446",
@@ -1018,9 +1018,9 @@
         "MarkExecution": "#949cbb",
         "MarkWarning": "#ef9f76",
         "ModifiedLines": "#ef9f76",
-        "ReplaceHighlight": "#66a6d189",
+        "ReplaceHighlight": "#8caaee80",
         "SavedLines": "#a6d189",
-        "SearchHighlight": "#668caaee",
+        "SearchHighlight": "#8caaeee6",
         "Separator": "#232634",
         "SpellChecking": "#ea999c",
         "TabMarker": "#414559",
@@ -1028,7 +1028,7 @@
         "TemplateFocusedPlaceholder": "#81c8be",
         "TemplatePlaceholder": "#85c1dc",
         "TemplateReadOnlyPlaceholder": "#ea999c",
-        "TextSelection": "#8c51576d",
+        "TextSelection": "#e7828480",
         "WordWrapMarker": "#626880"
     },
     "metadata": {

--- a/themes/latte.theme
+++ b/themes/latte.theme
@@ -661,8 +661,8 @@
                 "text-color": "#8839ef"
             },
             "Inline Image": {
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#7287fd",
+                "text-color": "#7287fd"
             },
             "Inline Image: Link": {
                 "italic": true,
@@ -740,17 +740,17 @@
             },
             "Reference-Link ID": {
                 "italic": true,
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#7287fd",
+                "text-color": "#7287fd"
             },
             "Reference-Link Name": {
                 "italic": true,
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#7287fd",
+                "text-color": "#7287fd"
             },
             "Reference-Link Target": {
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#7287fd",
+                "text-color": "#7287fd"
             },
             "Reference-Link Target: Link": {
                 "italic": true,
@@ -1003,8 +1003,8 @@
     },
     "editor-colors": {
         "BackgroundColor": "#eff1f5",
-        "BracketMatching": "#32dd7878",
-        "CodeFolding": "#6699d1db",
+        "BracketMatching": "#179299",
+        "CodeFolding": "#209fb5",
         "CurrentLine": "#ccd0da",
         "CurrentLineNumber": "#4c4f69",
         "IconBorder": "#eff1f5",
@@ -1018,9 +1018,9 @@
         "MarkExecution": "#7c7f93",
         "MarkWarning": "#fe640b",
         "ModifiedLines": "#fe640b",
-        "ReplaceHighlight": "#6640a02b",
+        "ReplaceHighlight": "#1e66f580",
         "SavedLines": "#40a02b",
-        "SearchHighlight": "#661e66f5",
+        "SearchHighlight": "#1e66f5e6",
         "Separator": "#dce0e8",
         "SpellChecking": "#e64553",
         "TabMarker": "#ccd0da",
@@ -1028,7 +1028,7 @@
         "TemplateFocusedPlaceholder": "#179299",
         "TemplatePlaceholder": "#209fb5",
         "TemplateReadOnlyPlaceholder": "#e64553",
-        "TextSelection": "#8cbcc0cc",
+        "TextSelection": "#d20f3980",
         "WordWrapMarker": "#acb0be"
     },
     "metadata": {

--- a/themes/macchiato.theme
+++ b/themes/macchiato.theme
@@ -661,8 +661,8 @@
                 "text-color": "#c6a0f6"
             },
             "Inline Image": {
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#b7bdf8",
+                "text-color": "#b7bdf8"
             },
             "Inline Image: Link": {
                 "italic": true,
@@ -740,17 +740,17 @@
             },
             "Reference-Link ID": {
                 "italic": true,
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#b7bdf8",
+                "text-color": "#b7bdf8"
             },
             "Reference-Link Name": {
                 "italic": true,
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#b7bdf8",
+                "text-color": "#b7bdf8"
             },
             "Reference-Link Target": {
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#b7bdf8",
+                "text-color": "#b7bdf8"
             },
             "Reference-Link Target: Link": {
                 "italic": true,
@@ -1003,8 +1003,8 @@
     },
     "editor-colors": {
         "BackgroundColor": "#24273a",
-        "BracketMatching": "#32f0c6c6",
-        "CodeFolding": "#1a91d7e3",
+        "BracketMatching": "#8bd5ca",
+        "CodeFolding": "#7dc4e4",
         "CurrentLine": "#363a4f",
         "CurrentLineNumber": "#cad3f5",
         "IconBorder": "#24273a",
@@ -1018,9 +1018,9 @@
         "MarkExecution": "#939ab7",
         "MarkWarning": "#f5a97f",
         "ModifiedLines": "#f5a97f",
-        "ReplaceHighlight": "#66a6da95",
+        "ReplaceHighlight": "#8aadf480",
         "SavedLines": "#a6da95",
-        "SearchHighlight": "#668aadf4",
+        "SearchHighlight": "#8aadf4e6",
         "Separator": "#181926",
         "SpellChecking": "#ee99a0",
         "TabMarker": "#363a4f",
@@ -1028,7 +1028,7 @@
         "TemplateFocusedPlaceholder": "#8bd5ca",
         "TemplatePlaceholder": "#7dc4e4",
         "TemplateReadOnlyPlaceholder": "#ee99a0",
-        "TextSelection": "#8c494d64",
+        "TextSelection": "#ed879680",
         "WordWrapMarker": "#5b6078"
     },
     "metadata": {

--- a/themes/mocha.theme
+++ b/themes/mocha.theme
@@ -302,12 +302,12 @@
                 "text-color": "#f38ba8"
             },
             "Redirection": {
-                "selected-text-color": "#99d1db",
-                "text-color": "#99d1db"
+                "selected-text-color": "#89dceb",
+                "text-color": "#89dceb"
             },
             "Separator": {
-                "selected-text-color": "#81c8be",
-                "text-color": "#81c8be"
+                "selected-text-color": "#94e2d5",
+                "text-color": "#94e2d5"
             },
             "Variable": {
                 "selected-text-color": "#cdd6f4",
@@ -661,8 +661,8 @@
                 "text-color": "#cba6f7"
             },
             "Inline Image": {
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#b4befe",
+                "text-color": "#b4befe"
             },
             "Inline Image: Link": {
                 "italic": true,
@@ -740,17 +740,17 @@
             },
             "Reference-Link ID": {
                 "italic": true,
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#b4befe",
+                "text-color": "#b4befe"
             },
             "Reference-Link Name": {
                 "italic": true,
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#b4befe",
+                "text-color": "#b4befe"
             },
             "Reference-Link Target": {
-                "selected-text-color": "#b4befc",
-                "text-color": "#b4befc"
+                "selected-text-color": "#b4befe",
+                "text-color": "#b4befe"
             },
             "Reference-Link Target: Link": {
                 "italic": true,
@@ -1003,13 +1003,13 @@
     },
     "editor-colors": {
         "BackgroundColor": "#1e1e2e",
-        "BracketMatching": "#32f5e0dc",
-        "CodeFolding": "#1a89dceb",
-        "CurrentLine": "#66313244",
-        "CurrentLineNumber": "#6c7086",
+        "BracketMatching": "#94e2d5",
+        "CodeFolding": "#74c7ec",
+        "CurrentLine": "#313244",
+        "CurrentLineNumber": "#cdd6f4",
         "IconBorder": "#1e1e2e",
         "IndentationLine": "#313244",
-        "LineNumbers": "#6c7086",
+        "LineNumbers": "#a6adc8",
         "MarkBookmark": "#cba6f7",
         "MarkBreakpointActive": "#f5c2e7",
         "MarkBreakpointDisabled": "#6c7086",
@@ -1018,9 +1018,9 @@
         "MarkExecution": "#9399b2",
         "MarkWarning": "#fab387",
         "ModifiedLines": "#fab387",
-        "ReplaceHighlight": "#66a6e3a1",
+        "ReplaceHighlight": "#89b4fa80",
         "SavedLines": "#a6e3a1",
-        "SearchHighlight": "#6689b4fa",
+        "SearchHighlight": "#89b4fae6",
         "Separator": "#11111b",
         "SpellChecking": "#eba0ac",
         "TabMarker": "#313244",
@@ -1028,7 +1028,7 @@
         "TemplateFocusedPlaceholder": "#94e2d5",
         "TemplatePlaceholder": "#74c7ec",
         "TemplateReadOnlyPlaceholder": "#eba0ac",
-        "TextSelection": "#8c45475a",
+        "TextSelection": "#f38ba880",
         "WordWrapMarker": "#585b70"
     },
     "metadata": {


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's in-house templating tool, to build the themes. Instead of editing the `.theme` files directly, edit the `ksyntaxhighlighting.tera` file and then run `whiskers ksyntaxhighlighting.tera` to build the output themes. You will need Whiskers (linked above) installed.

Note: some colors weren't valid Catppuccin colors, so I did my best to approximate the closest match.