### PR TITLE
fix: color changes to maintain readability

### DIFF
--- a/ksyntaxhighlighting.tera
+++ b/ksyntaxhighlighting.tera
@@ -4,6 +4,7 @@ whiskers:
   matrix:
     - flavor
   filename: "themes/{{ flavor.identifier }}.theme"
+  hex_format: "{{z}}{{r}}{{g}}{{b}}"
 ---
 {
     "custom-styles": {
@@ -519,9 +520,6 @@ whiskers:
             "Property": {
                 "selected-text-color": "#{{ flamingo.hex }}",
                 "text-color": "#{{ flamingo.hex }}"
-            },
-            "Source": {
-                "text-color": "#f50000"
             }
         },
         "Kotlin": {
@@ -1010,24 +1008,24 @@ whiskers:
     },
     "editor-colors": {
         "BackgroundColor": "#{{ base.hex }}",
-        "BracketMatching": "#{{ teal.hex }}",
-        "CodeFolding": "#{{ sapphire.hex }}",
+        "BracketMatching": "#{{ overlay0.hex }}",
+        "CodeFolding": "#{{ sky | mod(opacity=0.2) | get(key="hex") }}",
         "CurrentLine": "#{{ surface0.hex }}",
-        "CurrentLineNumber": "#{{ text.hex }}",
+        "CurrentLineNumber": "#{{ lavender.hex }}",
         "IconBorder": "#{{ base.hex }}",
         "IndentationLine": "#{{ surface0.hex }}",
-        "LineNumbers": "#{{ subtext0.hex }}",
+        "LineNumbers": "#{{ overlay1.hex }}",
         "MarkBookmark": "#{{ mauve.hex }}",
-        "MarkBreakpointActive": "#{{ pink.hex }}",
+        "MarkBreakpointActive": "#{{ red.hex }}",
         "MarkBreakpointDisabled": "#{{ overlay0.hex }}",
-        "MarkBreakpointReached": "#{{ green.hex }}",
+        "MarkBreakpointReached": "#{{ yellow.hex }}",
         "MarkError": "#{{ red.hex }}",
         "MarkExecution": "#{{ overlay2.hex }}",
         "MarkWarning": "#{{ peach.hex }}",
         "ModifiedLines": "#{{ peach.hex }}",
-        "ReplaceHighlight": "#{{ blue | mod(opacity=0.5) | get(key="hex") }}",
+        "ReplaceHighlight": "#{{ teal | mod(opacity=0.5) | get(key="hex") }}",
         "SavedLines": "#{{ green.hex }}",
-        "SearchHighlight": "#{{ blue | mod(opacity=0.9) | get(key="hex") }}",
+        "SearchHighlight": "#{{ teal | mod(opacity=0.5) | get(key="hex") }}",
         "Separator": "#{{ crust.hex }}",
         "SpellChecking": "#{{ maroon.hex }}",
         "TabMarker": "#{{ surface0.hex }}",
@@ -1035,7 +1033,7 @@ whiskers:
         "TemplateFocusedPlaceholder": "#{{ teal.hex }}",
         "TemplatePlaceholder": "#{{ sapphire.hex }}",
         "TemplateReadOnlyPlaceholder": "#{{ maroon.hex }}",
-        "TextSelection": "#{{ red | mod(opacity=0.5) | get(key="hex") }}",
+        "TextSelection": "#{{ overlay2 | mod(opacity=0.25) | get(key="hex") }}",
         "WordWrapMarker": "#{{ surface2.hex }}"
     },
     "metadata": {
@@ -1044,7 +1042,7 @@ whiskers:
         ],
         "license": "SPDX-License-Identifier: MIT",
         "name": "Catppuccin {{ flavor.name }}",
-        "revision": 3
+        "revision": 4
     },
     "text-styles": {
         "Alert": {

--- a/themes/frappe.theme
+++ b/themes/frappe.theme
@@ -512,9 +512,6 @@
             "Property": {
                 "selected-text-color": "#eebebe",
                 "text-color": "#eebebe"
-            },
-            "Source": {
-                "text-color": "#f50000"
             }
         },
         "Kotlin": {
@@ -1003,24 +1000,24 @@
     },
     "editor-colors": {
         "BackgroundColor": "#303446",
-        "BracketMatching": "#81c8be",
-        "CodeFolding": "#85c1dc",
+        "BracketMatching": "#737994",
+        "CodeFolding": "#3399d1db",
         "CurrentLine": "#414559",
-        "CurrentLineNumber": "#c6d0f5",
+        "CurrentLineNumber": "#babbf1",
         "IconBorder": "#303446",
         "IndentationLine": "#414559",
-        "LineNumbers": "#a5adce",
+        "LineNumbers": "#838ba7",
         "MarkBookmark": "#ca9ee6",
-        "MarkBreakpointActive": "#f4b8e4",
+        "MarkBreakpointActive": "#e78284",
         "MarkBreakpointDisabled": "#737994",
-        "MarkBreakpointReached": "#a6d189",
+        "MarkBreakpointReached": "#e5c890",
         "MarkError": "#e78284",
         "MarkExecution": "#949cbb",
         "MarkWarning": "#ef9f76",
         "ModifiedLines": "#ef9f76",
-        "ReplaceHighlight": "#8caaee80",
+        "ReplaceHighlight": "#8081c8be",
         "SavedLines": "#a6d189",
-        "SearchHighlight": "#8caaeee6",
+        "SearchHighlight": "#8081c8be",
         "Separator": "#232634",
         "SpellChecking": "#ea999c",
         "TabMarker": "#414559",
@@ -1028,7 +1025,7 @@
         "TemplateFocusedPlaceholder": "#81c8be",
         "TemplatePlaceholder": "#85c1dc",
         "TemplateReadOnlyPlaceholder": "#ea999c",
-        "TextSelection": "#e7828480",
+        "TextSelection": "#40949cbb",
         "WordWrapMarker": "#626880"
     },
     "metadata": {
@@ -1037,7 +1034,7 @@
         ],
         "license": "SPDX-License-Identifier: MIT",
         "name": "Catppuccin Frappé",
-        "revision": 3
+        "revision": 4
     },
     "text-styles": {
         "Alert": {

--- a/themes/latte.theme
+++ b/themes/latte.theme
@@ -512,9 +512,6 @@
             "Property": {
                 "selected-text-color": "#dd7878",
                 "text-color": "#dd7878"
-            },
-            "Source": {
-                "text-color": "#f50000"
             }
         },
         "Kotlin": {
@@ -1003,24 +1000,24 @@
     },
     "editor-colors": {
         "BackgroundColor": "#eff1f5",
-        "BracketMatching": "#179299",
-        "CodeFolding": "#209fb5",
+        "BracketMatching": "#9ca0b0",
+        "CodeFolding": "#3304a5e5",
         "CurrentLine": "#ccd0da",
-        "CurrentLineNumber": "#4c4f69",
+        "CurrentLineNumber": "#7287fd",
         "IconBorder": "#eff1f5",
         "IndentationLine": "#ccd0da",
-        "LineNumbers": "#6c6f85",
+        "LineNumbers": "#8c8fa1",
         "MarkBookmark": "#8839ef",
-        "MarkBreakpointActive": "#ea76cb",
+        "MarkBreakpointActive": "#d20f39",
         "MarkBreakpointDisabled": "#9ca0b0",
-        "MarkBreakpointReached": "#40a02b",
+        "MarkBreakpointReached": "#df8e1d",
         "MarkError": "#d20f39",
         "MarkExecution": "#7c7f93",
         "MarkWarning": "#fe640b",
         "ModifiedLines": "#fe640b",
-        "ReplaceHighlight": "#1e66f580",
+        "ReplaceHighlight": "#80179299",
         "SavedLines": "#40a02b",
-        "SearchHighlight": "#1e66f5e6",
+        "SearchHighlight": "#80179299",
         "Separator": "#dce0e8",
         "SpellChecking": "#e64553",
         "TabMarker": "#ccd0da",
@@ -1028,7 +1025,7 @@
         "TemplateFocusedPlaceholder": "#179299",
         "TemplatePlaceholder": "#209fb5",
         "TemplateReadOnlyPlaceholder": "#e64553",
-        "TextSelection": "#d20f3980",
+        "TextSelection": "#407c7f93",
         "WordWrapMarker": "#acb0be"
     },
     "metadata": {
@@ -1037,7 +1034,7 @@
         ],
         "license": "SPDX-License-Identifier: MIT",
         "name": "Catppuccin Latte",
-        "revision": 3
+        "revision": 4
     },
     "text-styles": {
         "Alert": {

--- a/themes/macchiato.theme
+++ b/themes/macchiato.theme
@@ -512,9 +512,6 @@
             "Property": {
                 "selected-text-color": "#f0c6c6",
                 "text-color": "#f0c6c6"
-            },
-            "Source": {
-                "text-color": "#f50000"
             }
         },
         "Kotlin": {
@@ -1003,24 +1000,24 @@
     },
     "editor-colors": {
         "BackgroundColor": "#24273a",
-        "BracketMatching": "#8bd5ca",
-        "CodeFolding": "#7dc4e4",
+        "BracketMatching": "#6e738d",
+        "CodeFolding": "#3391d7e3",
         "CurrentLine": "#363a4f",
-        "CurrentLineNumber": "#cad3f5",
+        "CurrentLineNumber": "#b7bdf8",
         "IconBorder": "#24273a",
         "IndentationLine": "#363a4f",
-        "LineNumbers": "#a5adcb",
+        "LineNumbers": "#8087a2",
         "MarkBookmark": "#c6a0f6",
-        "MarkBreakpointActive": "#f5bde6",
+        "MarkBreakpointActive": "#ed8796",
         "MarkBreakpointDisabled": "#6e738d",
-        "MarkBreakpointReached": "#a6da95",
+        "MarkBreakpointReached": "#eed49f",
         "MarkError": "#ed8796",
         "MarkExecution": "#939ab7",
         "MarkWarning": "#f5a97f",
         "ModifiedLines": "#f5a97f",
-        "ReplaceHighlight": "#8aadf480",
+        "ReplaceHighlight": "#808bd5ca",
         "SavedLines": "#a6da95",
-        "SearchHighlight": "#8aadf4e6",
+        "SearchHighlight": "#808bd5ca",
         "Separator": "#181926",
         "SpellChecking": "#ee99a0",
         "TabMarker": "#363a4f",
@@ -1028,7 +1025,7 @@
         "TemplateFocusedPlaceholder": "#8bd5ca",
         "TemplatePlaceholder": "#7dc4e4",
         "TemplateReadOnlyPlaceholder": "#ee99a0",
-        "TextSelection": "#ed879680",
+        "TextSelection": "#40939ab7",
         "WordWrapMarker": "#5b6078"
     },
     "metadata": {
@@ -1037,7 +1034,7 @@
         ],
         "license": "SPDX-License-Identifier: MIT",
         "name": "Catppuccin Macchiato",
-        "revision": 3
+        "revision": 4
     },
     "text-styles": {
         "Alert": {

--- a/themes/mocha.theme
+++ b/themes/mocha.theme
@@ -512,9 +512,6 @@
             "Property": {
                 "selected-text-color": "#f2cdcd",
                 "text-color": "#f2cdcd"
-            },
-            "Source": {
-                "text-color": "#f50000"
             }
         },
         "Kotlin": {
@@ -1003,24 +1000,24 @@
     },
     "editor-colors": {
         "BackgroundColor": "#1e1e2e",
-        "BracketMatching": "#94e2d5",
-        "CodeFolding": "#74c7ec",
+        "BracketMatching": "#6c7086",
+        "CodeFolding": "#3389dceb",
         "CurrentLine": "#313244",
-        "CurrentLineNumber": "#cdd6f4",
+        "CurrentLineNumber": "#b4befe",
         "IconBorder": "#1e1e2e",
         "IndentationLine": "#313244",
-        "LineNumbers": "#a6adc8",
+        "LineNumbers": "#7f849c",
         "MarkBookmark": "#cba6f7",
-        "MarkBreakpointActive": "#f5c2e7",
+        "MarkBreakpointActive": "#f38ba8",
         "MarkBreakpointDisabled": "#6c7086",
-        "MarkBreakpointReached": "#a6e3a1",
+        "MarkBreakpointReached": "#f9e2af",
         "MarkError": "#f38ba8",
         "MarkExecution": "#9399b2",
         "MarkWarning": "#fab387",
         "ModifiedLines": "#fab387",
-        "ReplaceHighlight": "#89b4fa80",
+        "ReplaceHighlight": "#8094e2d5",
         "SavedLines": "#a6e3a1",
-        "SearchHighlight": "#89b4fae6",
+        "SearchHighlight": "#8094e2d5",
         "Separator": "#11111b",
         "SpellChecking": "#eba0ac",
         "TabMarker": "#313244",
@@ -1028,7 +1025,7 @@
         "TemplateFocusedPlaceholder": "#94e2d5",
         "TemplatePlaceholder": "#74c7ec",
         "TemplateReadOnlyPlaceholder": "#eba0ac",
-        "TextSelection": "#f38ba880",
+        "TextSelection": "#409399b2",
         "WordWrapMarker": "#585b70"
     },
     "metadata": {
@@ -1037,7 +1034,7 @@
         ],
         "license": "SPDX-License-Identifier: MIT",
         "name": "Catppuccin Mocha",
-        "revision": 3
+        "revision": 4
     },
     "text-styles": {
         "Alert": {


### PR DESCRIPTION
Reverted colours within the ksyntaxhighlighting.tera to maintain readability. Also modified some colours to better match style docs.